### PR TITLE
fix: prevent from duplicate view setup.

### DIFF
--- a/ios/RNPopoverHostView.m
+++ b/ios/RNPopoverHostView.m
@@ -29,6 +29,7 @@
 
 @property (nonatomic, copy) RCTPromiseResolveBlock dismissResolve;
 @property (nonatomic, copy) RCTPromiseRejectBlock dismissReject;
+@property (nonatomic, assign) BOOL initialized;
 @property (nonatomic, assign) BOOL presented;
 
 @property (nonatomic, assign) CGRect realSourceRect;
@@ -53,6 +54,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder
 - (instancetype _Nonnull)initWithBridge:(RCTBridge *_Nullable)bridge {
     if ((self = [super initWithFrame:CGRectZero])) {
         _bridge = bridge;
+        _initialized = NO;
         _presented = NO;
         _animated = YES;
         _cancelable = YES;
@@ -97,9 +99,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder
 - (void)didMoveToWindow {
     [super didMoveToWindow];
 
-    if (!_presented && self.window) {
+    if (!_initialized && self.window) {
         RCTAssert(self.reactViewController, @"Can't present popover view controller without a presenting view controller");
 
+        _initialized = YES;
         _popoverHostViewController.view.backgroundColor = _popoverBackgroundColor;
         
         UIView *sourceView = [self autoGetSourceView];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-popover-ios",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A native popover component for react-native, iOS only.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Prevent from duplicate setup which may cause unexpected popover present after dismiss in some cases.
Here is one of the cases may cause the issue:  [RN code comment](https://github.com/facebook/react-native/blob/0ec1017660602d6b3ae84b4d7a444cbd49ba0d53/React/Modules/RCTUIManager.m#L765)